### PR TITLE
mpeg4audio: support otherDataPresent and crcCheckPresent of StreamMuxConfig

### DIFF
--- a/pkg/codecs/mpeg2audio/frame_header.go
+++ b/pkg/codecs/mpeg2audio/frame_header.go
@@ -46,7 +46,7 @@ var sampleRates = map[uint8]int{
 	0b10: 32000,
 }
 
-// ChannelMode is a channel mode of a MPEG-2 or MPEG-2 audio frame.
+// ChannelMode is a channel mode of a MPEG-1/2 audio frame.
 type ChannelMode int
 
 // standard channel modes.
@@ -57,7 +57,7 @@ const (
 	ChannelModeMono        ChannelMode = 3
 )
 
-// FrameHeader is the header of a MPEG-1 or MPEG-2 audio frame.
+// FrameHeader is the header of a MPEG-1/2 audio frame.
 type FrameHeader struct {
 	MPEG2       bool
 	Layer       uint8

--- a/pkg/codecs/mpeg2audio/mpeg2audio.go
+++ b/pkg/codecs/mpeg2audio/mpeg2audio.go
@@ -1,2 +1,2 @@
-// Package mpeg2audio contains utilities to work with MPEG-1 and MPEG-2 audio codecs.
+// Package mpeg2audio contains utilities to work with MPEG-1/2 audio codecs.
 package mpeg2audio

--- a/pkg/codecs/mpeg4audio/stream_mux_config_test.go
+++ b/pkg/codecs/mpeg4audio/stream_mux_config_test.go
@@ -79,6 +79,46 @@ var streamMuxConfigCases = []struct {
 			}},
 		},
 	},
+	{
+		"other data and checksum",
+		[]byte{0x40, 0x00, 0x24, 0x10, 0xad, 0xca, 0x00},
+		StreamMuxConfig{
+			Programs: []*StreamMuxConfigProgram{{
+				Layers: []*StreamMuxConfigLayer{{
+					AudioSpecificConfig: &AudioSpecificConfig{
+						Type:         2,
+						SampleRate:   44100,
+						ChannelCount: 1,
+					},
+					FrameLengthType: 2,
+				}},
+			}},
+			OtherDataPresent: true,
+			OtherDataLenBits: 220,
+			CRCCheckPresent:  true,
+			CRCCheckSum:      64,
+		},
+	},
+	{
+		"other data > 256 and checksum",
+		[]byte{0x40, 0x00, 0x24, 0x10, 0xb0, 0x33, 0x85, 0x0},
+		StreamMuxConfig{
+			Programs: []*StreamMuxConfigProgram{{
+				Layers: []*StreamMuxConfigLayer{{
+					AudioSpecificConfig: &AudioSpecificConfig{
+						Type:         2,
+						SampleRate:   44100,
+						ChannelCount: 1,
+					},
+					FrameLengthType: 2,
+				}},
+			}},
+			OtherDataPresent: true,
+			OtherDataLenBits: 880,
+			CRCCheckPresent:  true,
+			CRCCheckSum:      64,
+		},
+	},
 }
 
 func TestStreamMuxConfigUnmarshal(t *testing.T) {


### PR DESCRIPTION
(https://github.com/bluenviron/mediamtx/issues/1881)