### PR TITLE
h264, h265: raise MaxNALUSize

### DIFF
--- a/pkg/codecs/h264/h264.go
+++ b/pkg/codecs/h264/h264.go
@@ -3,8 +3,8 @@ package h264
 
 const (
 	// MaxNALUSize is the maximum size of a NALU.
-	// with a 250 Mbps H264 video, the maximum NALU size is 2.2MB
-	MaxNALUSize = 3 * 1024 * 1024
+	// With a 50 Mbps 2160p60 H264 video, the maximum NALU size does not seem to exceed 4 MiB.
+	MaxNALUSize = 4 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
 	MaxNALUsPerAccessUnit = 20

--- a/pkg/codecs/h265/h265.go
+++ b/pkg/codecs/h265/h265.go
@@ -3,8 +3,8 @@ package h265
 
 const (
 	// MaxNALUSize is the maximum size of a NALU.
-	// with a 250 Mbps H265 video, the maximum NALU size is 2.2MB
-	MaxNALUSize = 3 * 1024 * 1024
+	// With a 50 Mbps 2160p60 H265 video, the maximum NALU size does not seem to exceed 4 MiB.
+	MaxNALUSize = 4 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
 	MaxNALUsPerAccessUnit = 20


### PR DESCRIPTION
When streaming a 50Mbps 2160p60 HEVC video encoded by AMD AMF from OBS via RTMP, none of the frames can get through:

```
unable to decode AVCC: NALU size (3497231) is too big, maximum is 3145728
```

Reducing the resolution to 1440p allows most of the frames to get through, but the same error still appears about once every 15 minutes:

```
unable to decode AVCC: NALU size (3464043) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3463992) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3463991) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3417504) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3417342) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3372157) is too big, maximum is 3145728
unable to decode AVCC: NALU size (3314591) is too big, maximum is 3145728
```

Raising the size limit to 4 MiB seems to have resolved the issue for me. Updated the comment as well.