### PR TITLE
h264, h265: raise MaxAccessUnitSize to 8 MiB

### DIFF
--- a/pkg/codecs/h264/h264.go
+++ b/pkg/codecs/h264/h264.go
@@ -3,8 +3,8 @@ package h264
 
 const (
 	// MaxAccessUnitSize is the maximum size of an access unit.
-	// With a 50 Mbps 2160p60 H264 video, the maximum size does not seem to exceed 4 MiB.
-	MaxAccessUnitSize = 4 * 1024 * 1024
+	// With a 50 Mbps 2160p60 H264 video, the maximum size does not seem to exceed 8 MiB.
+	MaxAccessUnitSize = 8 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
 	MaxNALUsPerAccessUnit = 20

--- a/pkg/codecs/h265/h265.go
+++ b/pkg/codecs/h265/h265.go
@@ -3,8 +3,8 @@ package h265
 
 const (
 	// MaxAccessUnitSize is the maximum size of an access unit.
-	// With a 50 Mbps 2160p60 H265 video, the maximum size does not seem to exceed 4 MiB.
-	MaxAccessUnitSize = 4 * 1024 * 1024
+	// With a 50 Mbps 2160p60 H265 video, the maximum size does not seem to exceed 8 MiB.
+	MaxAccessUnitSize = 8 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
 	MaxNALUsPerAccessUnit = 20


### PR DESCRIPTION
Haven't run into the issue again since raising the limit to 8 MiB, so I guess this is it.

Fixes #35