### PR TITLE
Raise maximum NALU count

### DIFF
--- a/pkg/codecs/h264/h264.go
+++ b/pkg/codecs/h264/h264.go
@@ -7,5 +7,5 @@ const (
 	MaxAccessUnitSize = 8 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
-	MaxNALUsPerAccessUnit = 20
+	MaxNALUsPerAccessUnit = 21
 )

--- a/pkg/codecs/h265/h265.go
+++ b/pkg/codecs/h265/h265.go
@@ -7,5 +7,5 @@ const (
 	MaxAccessUnitSize = 8 * 1024 * 1024
 
 	// MaxNALUsPerAccessUnit is the maximum number of NALUs per access unit.
-	MaxNALUsPerAccessUnit = 20
+	MaxNALUsPerAccessUnit = 21
 )


### PR DESCRIPTION
_First off: Awesome work! Thanks for taking your time to create such an awesome project._

Similar to https://github.com/bluenviron/mediacommon/commit/169c5a3e2b2a59787bf21f49c19ef0b525bf6573 here goes my humble request to raise the NAL limits a bit:

Raising the maximum NAL unit count from 20 to 21 allows for streaming with recent encoders' "zerolatency" tune mode.

Fixes the "unable to decode AVCC: NALU count (21) exceeds maximum allowed (20))" error messages and allows for potential sub-second latency streaming with older protocols (e.g. RTMP).