### PR TITLE
fix chroma_format_idc value for baseline profile

### DIFF
--- a/pkg/codecs/h264/sps.go
+++ b/pkg/codecs/h264/sps.go
@@ -554,7 +554,7 @@ func (s *SPS) Unmarshal(buf []byte) error {
 		}
 
 	default:
-		s.ChromaFormatIdc = 0
+		s.ChromaFormatIdc = 1
 		s.SeparateColourPlaneFlag = false
 		s.BitDepthLumaMinus8 = 0
 		s.BitDepthChromaMinus8 = 0


### PR DESCRIPTION
h.264 base, main, extended 에서 sps 에서 해상도(가로, 세로)를 추정하는데 정확한 값이 나오지 않는 버그가 있음.

66, 77, 88(base, main, extended) 에 대한 chroma_format_idc 의 기본값이 1(4:2:0) 으로 설정 되어야 

```go
Height(....) {
...
	var cropUnitY uint32
	if chromaArrayType == 0 {
		cropUnitY = 2 - frameMbsOnlyFlagUint32
	} else {
		cropUnitY = subHeightC * (2 - frameMbsOnlyFlagUint32)
	}
}
```

cropUnitY 를 올바르게 추정함.