### PR TITLE
bug(h264/h265): DTS may stay the same

### DIFF
--- a/pkg/codecs/h264/dts_extractor.go
+++ b/pkg/codecs/h264/dts_extractor.go
@@ -206,7 +206,7 @@ func (d *DTSExtractor) Extract(au [][]byte, pts time.Duration) (time.Duration, e
 		return 0, fmt.Errorf("DTS is greater than PTS")
 	}
 
-	if d.prevDTSFilled && dts <= d.prevDTS {
+	if d.prevDTSFilled && dts < d.prevDTS {
 		return 0, fmt.Errorf("DTS is not monotonically increasing, was %v, now is %v",
 			d.prevDTS, dts)
 	}

--- a/pkg/codecs/h265/dts_extractor.go
+++ b/pkg/codecs/h265/dts_extractor.go
@@ -227,7 +227,7 @@ func (d *DTSExtractor) Extract(au [][]byte, pts time.Duration) (time.Duration, e
 		return 0, fmt.Errorf("DTS is greater than PTS")
 	}
 
-	if d.prevDTSFilled && dts <= d.prevDTS {
+	if d.prevDTSFilled && dts < d.prevDTS {
 		return 0, fmt.Errorf("DTS is not monotonically increasing, was %v, now is %v",
 			d.prevDTS, dts)
 	}


### PR DESCRIPTION
Foe some reason in the code the monotonical increasing did forbid having the same value as before, while purely mathematical definition of a "monotonical increasing" does allow to have the same value. Fixing it.

ITS: https://github.com/bluenviron/mediamtx/issues/1002