### PR TITLE
KLV metadata handling

### DIFF
--- a/pkg/formats/mpegts/KLVA_access_unit.go
+++ b/pkg/formats/mpegts/KLVA_access_unit.go
@@ -1,0 +1,45 @@
+package mpegts
+
+import (
+	"fmt"
+)
+
+type klvaAccessUnit struct {
+	Packet []byte
+	Header metadataAuCellHeader
+}
+
+func (au *klvaAccessUnit) unmarshal(buf []byte) (int, error) {
+	n, err := au.Header.unmarshal(buf)
+	if err != nil {
+		return 0, fmt.Errorf("could not decode metadata AU header: %v", err)
+	}
+	//buf = buf[n:]
+
+	if len(buf) < au.Header.PayloadSize {
+		return 0, fmt.Errorf("buffer is too small")
+	}
+
+	au.Packet = buf[:] //au.Header.PayloadSize]
+
+	return n + au.Header.PayloadSize, nil
+}
+
+func (au *klvaAccessUnit) marshalSize() int {
+	return au.Header.PayloadSize
+}
+
+func (au *klvaAccessUnit) marshalTo(buf []byte) (int, error) {
+	if au.Header.PayloadSize != len(au.Packet) {
+		return 0, fmt.Errorf("invalid packet")
+	}
+
+	n, err := au.Header.marshalTo(buf)
+	if err != nil {
+		return 0, err
+	}
+
+	n += copy(buf[n:], au.Packet)
+
+	return n, nil
+}

--- a/pkg/formats/mpegts/codec_klv.go
+++ b/pkg/formats/mpegts/codec_klv.go
@@ -1,0 +1,38 @@
+package mpegts
+
+import (
+	"github.com/asticode/go-astits"
+)
+
+// CodecKLV is a KLV codec.
+type CodecKLV struct {
+	StreamType      astits.StreamType
+	StreamID        uint8
+	PTSDTSIndicator uint8
+}
+
+// IsVideo implements Codec.
+func (c CodecKLV) IsVideo() bool {
+	return false
+}
+
+// IsVideo implements Codec.
+func (*CodecKLV) isCodec() {}
+
+func (c CodecKLV) marshal(pid uint16) (*astits.PMTElementaryStream, error) {
+	return &astits.PMTElementaryStream{
+		ElementaryPID: pid,
+		ElementaryStreamDescriptors: []*astits.Descriptor{
+			{
+				Length: 4,
+				Tag:    astits.DescriptorTagRegistration,
+				Registration: &astits.DescriptorRegistration{
+					FormatIdentifier: klvaIdentifier,
+				},
+			},
+		},
+		StreamType: c.StreamType,
+		//StreamType: astits.StreamTypeMetadata,
+		//StreamType: astits.StreamTypePrivateData,
+	}, nil
+}

--- a/pkg/formats/mpegts/metadata_au_header.go
+++ b/pkg/formats/mpegts/metadata_au_header.go
@@ -1,0 +1,57 @@
+package mpegts
+
+import (
+	"fmt"
+	"github.com/bluenviron/mediacommon/pkg/bits"
+)
+
+type metadataAuCellHeader struct {
+	PayloadSize                 int
+	MetadataServiceID           uint8
+	CellFragmentationIndication uint8
+	DecoderConfigFlag           bool
+	RandomAccessIndicator       bool
+	SequenceNumber              uint8
+}
+
+func (h *metadataAuCellHeader) unmarshal(buf []byte) (int, error) {
+	pos := 0
+
+	err := bits.HasSpace(buf, pos, 40)
+	if err != nil {
+		return 0, err
+	}
+
+	h.MetadataServiceID = uint8(bits.ReadBitsUnsafe(buf, &pos, 8))
+	if h.MetadataServiceID != 0xFC {
+		return 0, fmt.Errorf("invalid prefix: %v", h.MetadataServiceID)
+	}
+	h.SequenceNumber = uint8(bits.ReadBitsUnsafe(buf, &pos, 8))
+	h.CellFragmentationIndication = uint8(bits.ReadBitsUnsafe(buf, &pos, 2))
+
+	h.DecoderConfigFlag = bits.ReadFlagUnsafe(buf, &pos)
+	h.RandomAccessIndicator = bits.ReadFlagUnsafe(buf, &pos)
+
+	pos += 4 // reserved
+
+	h.PayloadSize = int(bits.ReadBitsUnsafe(buf, &pos, 16))
+
+	return pos / 8, nil
+}
+
+func (h *metadataAuCellHeader) marshalTo(buf []byte) (int, error) {
+	buf[0] = byte(h.MetadataServiceID)
+	buf[1] = byte(h.SequenceNumber)
+	buf[2] = 0
+	buf[2] |= byte(h.CellFragmentationIndication << 6)
+	if h.DecoderConfigFlag {
+		buf[2] |= 1 << 5
+	}
+	if h.RandomAccessIndicator {
+		buf[2] |= 1 << 4
+	}
+	pos := 24
+	bits.WriteBits(buf, &pos, uint64(h.PayloadSize), 16)
+
+	return 5, nil
+}

--- a/pkg/formats/mpegts/writer.go
+++ b/pkg/formats/mpegts/writer.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	streamIDVideo = 224
-	streamIDAudio = 192
+	streamIDVideo        = 224
+	streamIDAudio        = 192
+	streamIDSyncMetadata = 252
 
 	// PCR is needed to read H265 tracks with VLC+VDPAU hardware encoder
 	// (and is probably needed by other combinations too)
@@ -198,6 +199,15 @@ func (w *Writer) WriteOpus(
 	return w.writeAudio(track, pts, enc)
 }
 
+// WriteKLV writes KLV packets.
+func (w *Writer) WriteKLV(
+	track *Track,
+	pts int64,
+	data []byte,
+) error {
+	return w.writeData(track, pts, data) //packet)
+}
+
 // WriteMPEG4Audio writes MPEG-4 Audio access units.
 func (w *Writer) WriteMPEG4Audio(
 	track *Track,
@@ -354,6 +364,53 @@ func (w *Writer) writeAudio(track *Track, pts int64, data []byte) error {
 				StreamID: streamIDAudio,
 			},
 			Data: data,
+		},
+	})
+	return err
+}
+
+func (w *Writer) writeData(track *Track, pts int64, data []byte) error {
+	if !w.leadingTrackChosen {
+		w.leadingTrackChosen = true
+		track.isLeading = true
+		w.mux.SetPCRPID(track.PID)
+	}
+
+	af := &astits.PacketAdaptationField{
+		RandomAccessIndicator: true,
+	}
+
+	if track.isLeading {
+		if w.pcrCounter == 0 {
+			af.HasPCR = true
+			af.PCR = &astits.ClockReference{Base: pts - dtsPCRDiff}
+			w.pcrCounter = 3
+		}
+		w.pcrCounter--
+	}
+	klvCodec := track.Codec.(*CodecKLV)
+
+	oh := &astits.PESOptionalHeader{
+		MarkerBits:      2,
+		PTSDTSIndicator: klvCodec.PTSDTSIndicator,
+		PTS:             nil,
+	}
+
+	if klvCodec.PTSDTSIndicator == astits.PTSDTSIndicatorOnlyPTS {
+		oh.PTS = &astits.ClockReference{Base: pts}
+	}
+
+	header := &astits.PESHeader{
+		StreamID:       klvCodec.StreamID,
+		OptionalHeader: oh,
+	}
+
+	_, err := w.mux.WriteData(&astits.MuxerData{
+		PID:             track.PID,
+		AdaptationField: af,
+		PES: &astits.PESData{
+			Header: header,
+			Data:   data,
 		},
 	})
 	return err


### PR DESCRIPTION
Changes to support KLV metadata handling in mediamtx.

See related KLV metadata pull requests in mediacommon, gortsplib, and mediamtx.

All these changes released to public domain for adding to parent project under parent project's license(s).