### PR TITLE
ac3: fix support for bsid different than 8 (bluenviron/mediamtx#4705)

### DIFF
--- a/pkg/codecs/ac3/bsi.go
+++ b/pkg/codecs/ac3/bsi.go
@@ -22,8 +22,8 @@ func (b *BSI) Unmarshal(buf []byte) error {
 	}
 
 	b.Bsid = buf[0] >> 3
-	if b.Bsid != 0x08 {
-		return fmt.Errorf("invalid bsid")
+	if b.Bsid > 8 {
+		return fmt.Errorf("unsupported bsid: %v", b.Bsid)
 	}
 
 	b.Bsmod = buf[0] & 0b111


### PR DESCRIPTION
Fixes bluenviron/mediamtx#4705