### PR TITLE
mpegts: extract ISO 639 language code from PMT descriptors

### DIFF
--- a/pkg/formats/mpegts/reader_test.go
+++ b/pkg/formats/mpegts/reader_test.go
@@ -1066,6 +1066,103 @@ var casesReadWriter = []struct {
 		},
 	},
 	{
+		"language",
+		&Track{
+			PID:      256,
+			Codec:    &codecs.H264{},
+			Language: "eng",
+		},
+		[]sample{
+			{
+				30 * 90000,
+				30 * 90000,
+				[][]byte{
+					testH264SPS, // SPS
+					{8},         // PPS
+					{5},         // IDR
+				},
+			},
+			{
+				30*90000 + 2*90000,
+				30*90000 + 1*90000,
+				[][]byte{
+					{1}, // non-IDR
+				},
+			},
+		},
+		[]*astits.Packet{
+			{ // PMT
+				Header: astits.PacketHeader{
+					HasPayload:                true,
+					PayloadUnitStartIndicator: true,
+					PID:                       0,
+				},
+				Payload: append([]byte{
+					0x00, 0x00, 0xb0, 0x0d, 0x00, 0x00, 0xc1, 0x00,
+					0x00, 0x00, 0x01, 0xf0, 0x00, 0x71, 0x10, 0xd8,
+					0x78,
+				}, bytes.Repeat([]byte{0xff}, 167)...),
+			},
+			{ // PAT
+				Header: astits.PacketHeader{
+					HasPayload:                true,
+					PayloadUnitStartIndicator: true,
+					PID:                       4096,
+				},
+				Payload: append([]byte{
+					0x00, 0x02, 0xb0, 0x18, 0x00, 0x01, 0xc1, 0x00,
+					0x00, 0xe1, 0x00, 0xf0, 0x00, 0x1b, 0xe1, 0x00,
+					0xf0, 0x06, 0x0a, 0x04, 0x65, 0x6e, 0x67, 0x00,
+					0xd9, 0xa5, 0xe1, 0x64,
+				}, bytes.Repeat([]byte{0xff}, 156)...),
+			},
+			{ // PES
+				AdaptationField: &astits.PacketAdaptationField{
+					Length:                124,
+					StuffingLength:        117,
+					RandomAccessIndicator: true,
+					HasPCR:                true,
+					PCR:                   &astits.ClockReference{Base: 2691000},
+				},
+				Header: astits.PacketHeader{
+					HasAdaptationField:        true,
+					HasPayload:                true,
+					PayloadUnitStartIndicator: true,
+					PID:                       256,
+				},
+				Payload: []byte{
+					0x00, 0x00, 0x01, 0xe0, 0x00, 0x00, 0x80, 0x80,
+					0x05, 0x21, 0x00, 0xa5, 0x65, 0xc1, 0x00, 0x00,
+					0x00, 0x01, 0x09, 0xf0, 0x00, 0x00, 0x00, 0x01,
+					0x67, 0x42, 0xc0, 0x28, 0xd9, 0x00, 0x78, 0x02,
+					0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00, 0x04,
+					0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60, 0xc9,
+					0x20, 0x00, 0x00, 0x00, 0x01, 0x08, 0x00, 0x00,
+					0x00, 0x01, 0x05,
+				},
+			},
+			{ // PES
+				AdaptationField: &astits.PacketAdaptationField{
+					Length:         153,
+					StuffingLength: 152,
+				},
+				Header: astits.PacketHeader{
+					ContinuityCounter:         1,
+					HasAdaptationField:        true,
+					HasPayload:                true,
+					PayloadUnitStartIndicator: true,
+					PID:                       256,
+				},
+				Payload: []byte{
+					0x00, 0x00, 0x01, 0xe0, 0x00, 0x00, 0x80, 0xc0,
+					0x0a, 0x31, 0x00, 0xaf, 0xe4, 0x01, 0x11, 0x00,
+					0xab, 0x24, 0xe1, 0x00, 0x00, 0x00, 0x01, 0x09,
+					0xf0, 0x00, 0x00, 0x00, 0x01, 0x01,
+				},
+			},
+		},
+	},
+	{
 		"dvb subtitles",
 		&Track{
 			PID: 257,

--- a/pkg/formats/mpegts/track.go
+++ b/pkg/formats/mpegts/track.go
@@ -319,6 +319,24 @@ func eac3ComponentType(channels int, fullService bool) uint8 {
 	return ct
 }
 
+// addLanguageDescriptor appends an ISO 639 language descriptor to es
+// if language is non-empty. astits pads/truncates to 3 bytes.
+func addLanguageDescriptor(es *astits.PMTElementaryStream, language string) *astits.PMTElementaryStream {
+	if language == "" {
+		return es
+	}
+	es.ElementaryStreamDescriptors = append(es.ElementaryStreamDescriptors, &astits.Descriptor{
+		// 3 bytes language + 1 byte audio_type = 4 bytes
+		Length: 4,
+		Tag:    astits.DescriptorTagISO639LanguageAndAudioType,
+		ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
+			Language: []byte(language),
+			Type:     0,
+		},
+	})
+	return es
+}
+
 // Track is a MPEG-TS track.
 type Track struct {
 	PID   uint16
@@ -336,29 +354,29 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 	// video
 
 	case *codecs.H265:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeH265Video,
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.H264:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeH264Video,
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.MPEG4Video:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeMPEG4Video,
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.MPEG1Video:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			// we use MPEG-2 to signal that video can be either MPEG-1 or MPEG-2
 			StreamType: astits.StreamTypeMPEG2Video,
-		}, nil
+		}, t.Language), nil
 
 	// audio
 
@@ -372,7 +390,7 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 
 		enc, _ := desc.Marshal()
 
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypePrivateData,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -399,10 +417,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.AC3:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAC3Audio,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -420,10 +438,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.EAC3:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeEAC3Audio,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -441,25 +459,25 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.MPEG4Audio:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAACAudio,
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.MPEG4AudioLATM:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAACLATMAudio,
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.MPEG1Audio:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeMPEG1Audio,
-		}, nil
+		}, t.Language), nil
 
 		// other
 
@@ -486,7 +504,7 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 				return nil, err
 			}
 
-			return &astits.PMTElementaryStream{
+			return addLanguageDescriptor(&astits.PMTElementaryStream{
 				ElementaryPID: t.PID,
 				StreamType:    astits.StreamTypeMetadata,
 				ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -509,10 +527,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 						},
 					},
 				},
-			}, nil
+			}, t.Language), nil
 		}
 
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypePrivateData,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -526,10 +544,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, nil
+		}, t.Language), nil
 
 	case *codecs.DVBSubtitle:
-		return &astits.PMTElementaryStream{
+		return addLanguageDescriptor(&astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypePrivateData,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -543,7 +561,7 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, nil
+		}, t.Language), nil
 
 	default:
 		panic("unsupported codec")

--- a/pkg/formats/mpegts/track.go
+++ b/pkg/formats/mpegts/track.go
@@ -319,64 +319,72 @@ func eac3ComponentType(channels int, fullService bool) uint8 {
 	return ct
 }
 
-// addLanguageDescriptor appends an ISO 639 language descriptor to es
-// if language is non-empty. astits pads/truncates to 3 bytes.
-func addLanguageDescriptor(es *astits.PMTElementaryStream, language string) *astits.PMTElementaryStream {
-	if language == "" {
-		return es
-	}
-	es.ElementaryStreamDescriptors = append(es.ElementaryStreamDescriptors, &astits.Descriptor{
-		// 3 bytes language + 1 byte audio_type = 4 bytes
-		Length: 4,
-		Tag:    astits.DescriptorTagISO639LanguageAndAudioType,
-		ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
-			Language: []byte(language),
-			Type:     0,
-		},
-	})
-	return es
-}
-
 // Track is a MPEG-TS track.
 type Track struct {
-	PID   uint16
-	Codec codecs.Codec
-	// Language is the ISO 639 language code, populated from the
-	// ISO 639 language descriptor (tag 0x0A) when present in the PMT.
+	// PID.
+	PID uint16
+
+	// ISO 639 language code.
 	Language string
+
+	// Codec.
+	Codec codecs.Codec
 
 	isLeading  bool // Writer-only
 	mp3Checked bool // Writer-only
 }
 
+func (t *Track) unmarshal(dem *robustDemuxer, es *astits.PMTElementaryStream) error {
+	t.PID = es.ElementaryPID
+
+	for _, d := range es.ElementaryStreamDescriptors {
+		if d.Tag == astits.DescriptorTagISO639LanguageAndAudioType &&
+			d.ISO639LanguageAndAudioType != nil &&
+			len(d.ISO639LanguageAndAudioType.Language) >= 3 {
+			t.Language = string(d.ISO639LanguageAndAudioType.Language[:3])
+			break
+		}
+	}
+
+	codec, err := findCodec(dem, es)
+	if err != nil {
+		return err
+	}
+	t.Codec = codec
+
+	return nil
+}
+
 func (t Track) marshal() (*astits.PMTElementaryStream, error) {
+	var es *astits.PMTElementaryStream
+
 	switch c := t.Codec.(type) {
 	// video
 
 	case *codecs.H265:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeH265Video,
-		}, t.Language), nil
+		}
 
 	case *codecs.H264:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeH264Video,
-		}, t.Language), nil
+		}
 
 	case *codecs.MPEG4Video:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeMPEG4Video,
-		}, t.Language), nil
+		}
 
 	case *codecs.MPEG1Video:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			// we use MPEG-2 to signal that video can be either MPEG-1 or MPEG-2
 			StreamType: astits.StreamTypeMPEG2Video,
-		}, t.Language), nil
+		}
 
 	// audio
 
@@ -390,7 +398,7 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 
 		enc, _ := desc.Marshal()
 
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypePrivateData,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -417,10 +425,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, t.Language), nil
+		}
 
 	case *codecs.AC3:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAC3Audio,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -438,10 +446,10 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, t.Language), nil
+		}
 
 	case *codecs.EAC3:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeEAC3Audio,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -459,25 +467,25 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, t.Language), nil
+		}
 
 	case *codecs.MPEG4Audio:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAACAudio,
-		}, t.Language), nil
+		}
 
 	case *codecs.MPEG4AudioLATM:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeAACLATMAudio,
-		}, t.Language), nil
+		}
 
 	case *codecs.MPEG1Audio:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypeMPEG1Audio,
-		}, t.Language), nil
+		}
 
 		// other
 
@@ -504,7 +512,7 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 				return nil, err
 			}
 
-			return addLanguageDescriptor(&astits.PMTElementaryStream{
+			es = &astits.PMTElementaryStream{
 				ElementaryPID: t.PID,
 				StreamType:    astits.StreamTypeMetadata,
 				ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -527,27 +535,27 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 						},
 					},
 				},
-			}, t.Language), nil
-		}
-
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
-			ElementaryPID: t.PID,
-			StreamType:    astits.StreamTypePrivateData,
-			ElementaryStreamDescriptors: []*astits.Descriptor{
-				{
-					// Length must be different than zero.
-					// https://github.com/asticode/go-astits/blob/7c2bf6b71173d24632371faa01f28a9122db6382/descriptor.go#L2146-L2148
-					Length: 1,
-					Tag:    astits.DescriptorTagRegistration,
-					Registration: &astits.DescriptorRegistration{
-						FormatIdentifier: klvaIdentifier,
+			}
+		} else {
+			es = &astits.PMTElementaryStream{
+				ElementaryPID: t.PID,
+				StreamType:    astits.StreamTypePrivateData,
+				ElementaryStreamDescriptors: []*astits.Descriptor{
+					{
+						// Length must be different than zero.
+						// https://github.com/asticode/go-astits/blob/7c2bf6b71173d24632371faa01f28a9122db6382/descriptor.go#L2146-L2148
+						Length: 1,
+						Tag:    astits.DescriptorTagRegistration,
+						Registration: &astits.DescriptorRegistration{
+							FormatIdentifier: klvaIdentifier,
+						},
 					},
 				},
-			},
-		}, t.Language), nil
+			}
+		}
 
 	case *codecs.DVBSubtitle:
-		return addLanguageDescriptor(&astits.PMTElementaryStream{
+		es = &astits.PMTElementaryStream{
 			ElementaryPID: t.PID,
 			StreamType:    astits.StreamTypePrivateData,
 			ElementaryStreamDescriptors: []*astits.Descriptor{
@@ -561,30 +569,23 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 					},
 				},
 			},
-		}, t.Language), nil
+		}
 
 	default:
 		panic("unsupported codec")
 	}
-}
 
-func (t *Track) unmarshal(dem *robustDemuxer, es *astits.PMTElementaryStream) error {
-	t.PID = es.ElementaryPID
-
-	for _, d := range es.ElementaryStreamDescriptors {
-		if d.Tag == astits.DescriptorTagISO639LanguageAndAudioType &&
-			d.ISO639LanguageAndAudioType != nil &&
-			len(d.ISO639LanguageAndAudioType.Language) >= 3 {
-			t.Language = string(d.ISO639LanguageAndAudioType.Language[:3])
-			break
-		}
+	if t.Language != "" {
+		es.ElementaryStreamDescriptors = append(es.ElementaryStreamDescriptors, &astits.Descriptor{
+			// 3 bytes language + 1 byte audio_type = 4 bytes
+			Length: 4,
+			Tag:    astits.DescriptorTagISO639LanguageAndAudioType,
+			ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
+				Language: []byte(t.Language),
+				Type:     0,
+			},
+		})
 	}
 
-	codec, err := findCodec(dem, es)
-	if err != nil {
-		return err
-	}
-	t.Codec = codec
-
-	return nil
+	return es, nil
 }

--- a/pkg/formats/mpegts/track.go
+++ b/pkg/formats/mpegts/track.go
@@ -323,6 +323,9 @@ func eac3ComponentType(channels int, fullService bool) uint8 {
 type Track struct {
 	PID   uint16
 	Codec codecs.Codec
+	// Language is the ISO 639 language code, populated from the
+	// ISO 639 language descriptor (tag 0x0A) when present in the PMT.
+	Language string
 
 	isLeading  bool // Writer-only
 	mp3Checked bool // Writer-only
@@ -549,6 +552,15 @@ func (t Track) marshal() (*astits.PMTElementaryStream, error) {
 
 func (t *Track) unmarshal(dem *robustDemuxer, es *astits.PMTElementaryStream) error {
 	t.PID = es.ElementaryPID
+
+	for _, d := range es.ElementaryStreamDescriptors {
+		if d.Tag == astits.DescriptorTagISO639LanguageAndAudioType &&
+			d.ISO639LanguageAndAudioType != nil &&
+			len(d.ISO639LanguageAndAudioType.Language) >= 3 {
+			t.Language = string(d.ISO639LanguageAndAudioType.Language[:3])
+			break
+		}
+	}
 
 	codec, err := findCodec(dem, es)
 	if err != nil {

--- a/pkg/formats/mpegts/track_test.go
+++ b/pkg/formats/mpegts/track_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"testing"
 
-	"github.com/asticode/go-astits"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4audio"
@@ -712,86 +711,6 @@ func TestTrackUnmarshalExternal(t *testing.T) {
 			err = track.unmarshal(dem, pmt.ElementaryStreams[0])
 			require.NoError(t, err)
 			require.Equal(t, ca.track, &track)
-		})
-	}
-}
-
-func TestTrackUnmarshalLanguage(t *testing.T) {
-	for _, ca := range []struct {
-		name     string
-		desc     []*astits.Descriptor
-		language string
-	}{
-		{
-			"iso 639 present",
-			[]*astits.Descriptor{
-				{
-					Tag: astits.DescriptorTagISO639LanguageAndAudioType,
-					ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
-						Language: []byte{'f', 'r', 'a'},
-						Type:     0,
-					},
-				},
-			},
-			"fra",
-		},
-		{
-			"iso 639 absent",
-			nil,
-			"",
-		},
-		{
-			"iso 639 too short",
-			[]*astits.Descriptor{
-				{
-					Tag: astits.DescriptorTagISO639LanguageAndAudioType,
-					ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
-						Language: []byte{'f', 'r'},
-						Type:     0,
-					},
-				},
-			},
-			"",
-		},
-	} {
-		t.Run(ca.name, func(t *testing.T) {
-			es := &astits.PMTElementaryStream{
-				ElementaryPID:               257,
-				StreamType:                  astits.StreamTypeMPEG1Audio,
-				ElementaryStreamDescriptors: ca.desc,
-			}
-
-			var track Track
-			err := track.unmarshal(&robustDemuxer{R: bytes.NewReader(nil)}, es)
-			require.NoError(t, err)
-			require.Equal(t, ca.language, track.Language)
-		})
-	}
-}
-
-func TestTrackMarshalLanguage(t *testing.T) {
-	for _, ca := range []struct {
-		name     string
-		language string
-		want     string
-	}{
-		{"3-letter", "fra", "fra"},
-		{"empty", "", ""},
-	} {
-		t.Run(ca.name, func(t *testing.T) {
-			track := Track{
-				PID:      256,
-				Codec:    &codecs.MPEG1Audio{},
-				Language: ca.language,
-			}
-
-			es, err := track.marshal()
-			require.NoError(t, err)
-
-			var got Track
-			err = got.unmarshal(&robustDemuxer{R: bytes.NewReader(nil)}, es)
-			require.NoError(t, err)
-			require.Equal(t, ca.want, got.Language)
 		})
 	}
 }

--- a/pkg/formats/mpegts/track_test.go
+++ b/pkg/formats/mpegts/track_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/asticode/go-astits"
 	"github.com/stretchr/testify/require"
 
 	"github.com/bluenviron/mediacommon/v2/pkg/codecs/mpeg4audio"
@@ -633,6 +634,7 @@ func TestTrackUnmarshalExternal(t *testing.T) {
 						ChannelCount:  2,
 					},
 				},
+				Language: "eng",
 			},
 		},
 		{
@@ -695,6 +697,7 @@ func TestTrackUnmarshalExternal(t *testing.T) {
 					},
 					ChannelCount: 2,
 				},
+				Language: "deu",
 			},
 		},
 	} {
@@ -709,6 +712,59 @@ func TestTrackUnmarshalExternal(t *testing.T) {
 			err = track.unmarshal(dem, pmt.ElementaryStreams[0])
 			require.NoError(t, err)
 			require.Equal(t, ca.track, &track)
+		})
+	}
+}
+
+func TestTrackUnmarshalLanguage(t *testing.T) {
+	for _, ca := range []struct {
+		name     string
+		desc     []*astits.Descriptor
+		language string
+	}{
+		{
+			"iso 639 present",
+			[]*astits.Descriptor{
+				{
+					Tag: astits.DescriptorTagISO639LanguageAndAudioType,
+					ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
+						Language: []byte{'f', 'r', 'a'},
+						Type:     0,
+					},
+				},
+			},
+			"fra",
+		},
+		{
+			"iso 639 absent",
+			nil,
+			"",
+		},
+		{
+			"iso 639 too short",
+			[]*astits.Descriptor{
+				{
+					Tag: astits.DescriptorTagISO639LanguageAndAudioType,
+					ISO639LanguageAndAudioType: &astits.DescriptorISO639LanguageAndAudioType{
+						Language: []byte{'f', 'r'},
+						Type:     0,
+					},
+				},
+			},
+			"",
+		},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			es := &astits.PMTElementaryStream{
+				ElementaryPID:               257,
+				StreamType:                  astits.StreamTypeMPEG1Audio,
+				ElementaryStreamDescriptors: ca.desc,
+			}
+
+			var track Track
+			err := track.unmarshal(&robustDemuxer{R: bytes.NewReader(nil)}, es)
+			require.NoError(t, err)
+			require.Equal(t, ca.language, track.Language)
 		})
 	}
 }

--- a/pkg/formats/mpegts/track_test.go
+++ b/pkg/formats/mpegts/track_test.go
@@ -768,3 +768,30 @@ func TestTrackUnmarshalLanguage(t *testing.T) {
 		})
 	}
 }
+
+func TestTrackMarshalLanguage(t *testing.T) {
+	for _, ca := range []struct {
+		name     string
+		language string
+		want     string
+	}{
+		{"3-letter", "fra", "fra"},
+		{"empty", "", ""},
+	} {
+		t.Run(ca.name, func(t *testing.T) {
+			track := Track{
+				PID:      256,
+				Codec:    &codecs.MPEG1Audio{},
+				Language: ca.language,
+			}
+
+			es, err := track.marshal()
+			require.NoError(t, err)
+
+			var got Track
+			err = got.unmarshal(&robustDemuxer{R: bytes.NewReader(nil)}, es)
+			require.NoError(t, err)
+			require.Equal(t, ca.want, got.Language)
+		})
+	}
+}


### PR DESCRIPTION
Adds a `Language` field to `mpegts.Track`, populated by `unmarshal` from the ISO 639 language descriptor (tag 0x0A) when it's present in the elementary stream descriptors of the PMT.

I'm using this in mediamtx to expose audio language metadata in HLS renditions when a multi-language MPEG-TS is ingested via SRT. Right now the language code is dropped at the mpegts parser, so anything downstream is stuck. Related: bluenviron/mediamtx#4826.

If no descriptor is present the field stays empty, so existing behavior is unchanged.

Tested with:
- `go test ./pkg/formats/mpegts -count=1`
- `golangci-lint run ./...`
