### PR TITLE
fix: set array_completeness=1 on hvc1 VPS/SPS/PPS NALU arrays

### DIFF
--- a/internal/mp4/codec_boxes.go
+++ b/internal/mp4/codec_boxes.go
@@ -728,24 +728,29 @@ func WriteCodecBoxes(w *Writer, codec codecs.Codec, trackID int, info *CodecInfo
 			NumOfNaluArrays:    3,
 			NaluArrays: []amp4.HEVCNaluArray{
 				{
-					NaluType: byte(h265.NALUType_VPS_NUT),
-					NumNalus: 1,
+					// ISO/IEC 14496-15 §8.4.1.1.1: when sample-entry is hvc1,
+					// array_completeness MUST equal 1 for VPS/SPS/PPS arrays.
+					Completeness: true,
+					NaluType:     byte(h265.NALUType_VPS_NUT),
+					NumNalus:     1,
 					Nalus: []amp4.HEVCNalu{{
 						Length:  uint16(len(codec.VPS)),
 						NALUnit: codec.VPS,
 					}},
 				},
 				{
-					NaluType: byte(h265.NALUType_SPS_NUT),
-					NumNalus: 1,
+					Completeness: true,
+					NaluType:     byte(h265.NALUType_SPS_NUT),
+					NumNalus:     1,
 					Nalus: []amp4.HEVCNalu{{
 						Length:  uint16(len(codec.SPS)),
 						NALUnit: codec.SPS,
 					}},
 				},
 				{
-					NaluType: byte(h265.NALUType_PPS_NUT),
-					NumNalus: 1,
+					Completeness: true,
+					NaluType:     byte(h265.NALUType_PPS_NUT),
+					NumNalus:     1,
 					Nalus: []amp4.HEVCNalu{{
 						Length:  uint16(len(codec.PPS)),
 						NALUnit: codec.PPS,


### PR DESCRIPTION
## Summary

ISO/IEC 14496-15 §8.4.1.1.1 mandates that when the sample-entry box type is `hvc1`, the `array_completeness` flag **MUST equal 1** for the VPS, SPS, and PPS NALU arrays. The current code in `internal/mp4/codec_boxes.go` constructs `HEVCNaluArray` values without setting `Completeness`, leaving it at Go's zero-value `false`. This is a hard spec violation.

### Symptoms

- Chrome MediaSource Extensions rejects the source buffer with `bufferAppendError` / `MANIFEST_INCOMPATIBLE_CODECS_ERROR` when the `init.mp4` produced by this library is used in an fMP4/LL-HLS stream (e.g. via gohlslib).
- Captured init.mp4 from a live H.265 stream shows `0x20 / 0x21 / 0x22` at the VPS/SPS/PPS array header bytes — the top completeness bit is 0. With this fix they become `0xA0 / 0xA1 / 0xA2`.
- Live H.265 HEVC feeds produced via gohlslib (which uses mediacommon for init-segment generation) flash and immediately die on Chrome, even with HEVC hardware decode installed.

References:
- mediamtx issue #3662
- hls.js issue #6086

### Fix

Add `Completeness: true` to each of the three `HEVCNaluArray` structs in the `*codecs.H265` marshal path:

```go
NaluArrays: []amp4.HEVCNaluArray{
    {
        // ISO/IEC 14496-15 §8.4.1.1.1: hvc1 requires completeness=1
        Completeness: true,
        NaluType:     byte(h265.NALUType_VPS_NUT),
        ...
    },
    {
        Completeness: true,
        NaluType:     byte(h265.NALUType_SPS_NUT),
        ...
    },
    {
        Completeness: true,
        NaluType:     byte(h265.NALUType_PPS_NUT),
        ...
    },
},
```

### Note on hev1 vs hvc1

- `hvc1`: all parameter sets in the `hvcC` box, `array_completeness` MUST be 1 — this fix.
- `hev1`: parameter sets may be in-band, `array_completeness` = 0 is valid.

This library always writes `hvc1`, so `Completeness: true` is always correct.