### PR TITLE
h264: support SEI recovery point in DTS extractor

### DIFF
--- a/pkg/codecs/h264/dts_extractor.go
+++ b/pkg/codecs/h264/dts_extractor.go
@@ -109,6 +109,7 @@ func (d *DTSExtractor) extractInner(au [][]byte, pts int64) (int64, bool, error)
 	// 00 indicate that the decoding of the NAL unit is required to
 	// maintain the integrity of the reference pictures.
 	nonZeroNalRefIDFound := false
+	var seiRecoveryPoint bool
 
 outer:
 	for _, nalu := range au {
@@ -144,6 +145,11 @@ outer:
 		case NALUTypeNonIDR:
 			nonIDR = nalu
 			break outer
+
+		case NALUTypeSEI:
+			if isSEIRecoveryPoint(nalu) {
+				seiRecoveryPoint = true
+			}
 		}
 	}
 
@@ -160,7 +166,7 @@ outer:
 	}
 
 	if !d.randomReceived {
-		if idr == nil {
+		if idr == nil && (!seiRecoveryPoint || nonIDR == nil) {
 			return 0, false, fmt.Errorf("random access frame not received yet")
 		}
 		d.randomReceived = true
@@ -189,39 +195,60 @@ outer:
 		ptsDTSDiff = 0
 
 	case nonIDR != nil:
-		poc, err := getPictureOrderCount(nonIDR, d.spsp, false)
-		if err != nil {
-			return 0, false, err
-		}
-
-		if d.auCount < 5 && d.pocIncrement == 2 {
-			if (poc % 2) != 0 {
-				d.pocIncrement = 1
-				d.expectedPOC /= 2
-
-				if d.reorderedFrames != 0 {
-					increase := d.reorderedFrames
-					if (d.reorderedFrames + increase) > maxReorderedFrames {
-						return 0, false, fmt.Errorf("too many reordered frames (%d)", d.reorderedFrames+increase)
-					}
-
-					d.reorderedFrames += increase
-					d.pause += increase
-				}
-			} else if d.auCount >= 2 && (poc%4) == 0 && poc == (d.prevPOC+4) && d.prevPOC == (d.prevPrevPOC+4) {
-				d.pocIncrement = 4
-				d.expectedPOC *= 2
+		if seiRecoveryPoint && idr == nil {
+			// Like CRA in H265: initialize state from first frame after recovery point
+			var err error
+			d.expectedPOC, err = getPictureOrderCount(nonIDR, d.spsp, false)
+			if err != nil {
+				return 0, false, err
 			}
 
-			d.auCount++
-			d.prevPrevPOC = d.prevPOC
-			d.prevPOC = poc
+			if d.pocIncrement == 2 {
+				if (d.expectedPOC % 2) != 0 {
+					d.pocIncrement = 1
+				}
+
+				d.auCount = 1
+				d.prevPrevPOC = 0
+				d.prevPOC = d.expectedPOC
+			}
+
+			ptsDTSDiff = 0
+		} else {
+			poc, err := getPictureOrderCount(nonIDR, d.spsp, false)
+			if err != nil {
+				return 0, false, err
+			}
+
+			if d.auCount < 5 && d.pocIncrement == 2 {
+				if (poc % 2) != 0 {
+					d.pocIncrement = 1
+					d.expectedPOC /= 2
+
+					if d.reorderedFrames != 0 {
+						increase := d.reorderedFrames
+						if (d.reorderedFrames + increase) > maxReorderedFrames {
+							return 0, false, fmt.Errorf("too many reordered frames (%d)", d.reorderedFrames+increase)
+						}
+
+						d.reorderedFrames += increase
+						d.pause += increase
+					}
+				} else if d.auCount >= 2 && (poc%4) == 0 && poc == (d.prevPOC+4) && d.prevPOC == (d.prevPrevPOC+4) {
+					d.pocIncrement = 4
+					d.expectedPOC *= 2
+				}
+
+				d.auCount++
+				d.prevPrevPOC = d.prevPOC
+				d.prevPOC = poc
+			}
+
+			d.expectedPOC += uint32(d.pocIncrement)
+			d.expectedPOC &= ((1 << (d.spsp.Log2MaxPicOrderCntLsbMinus4 + 4)) - 1)
+
+			ptsDTSDiff = int(pictureOrderCountDiff(poc, d.expectedPOC, d.spsp)) / d.pocIncrement
 		}
-
-		d.expectedPOC += uint32(d.pocIncrement)
-		d.expectedPOC &= ((1 << (d.spsp.Log2MaxPicOrderCntLsbMinus4 + 4)) - 1)
-
-		ptsDTSDiff = int(pictureOrderCountDiff(poc, d.expectedPOC, d.spsp)) / d.pocIncrement
 
 	case !nonZeroNalRefIDFound:
 		if !d.prevDTSFilled {

--- a/pkg/codecs/h264/dts_extractor.go
+++ b/pkg/codecs/h264/dts_extractor.go
@@ -195,7 +195,7 @@ outer:
 		ptsDTSDiff = 0
 
 	case nonIDR != nil:
-		if seiRecoveryPoint && idr == nil {
+		if seiRecoveryPoint {
 			// Like CRA in H265: initialize state from first frame after recovery point
 			var err error
 			d.expectedPOC, err = getPictureOrderCount(nonIDR, d.spsp, false)

--- a/pkg/codecs/h264/dts_extractor_test.go
+++ b/pkg/codecs/h264/dts_extractor_test.go
@@ -582,6 +582,111 @@ var casesDTSExtractor = []struct {
 			},
 		},
 	},
+	{
+		"SEI recovery point",
+		[]sample{
+			{
+				[][]byte{
+					{ // SPS
+						0x67, 0x64, 0x00, 0x28, 0xac, 0xd9, 0x40, 0x78,
+						0x02, 0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00,
+						0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60,
+						0xc6, 0x58,
+					},
+					{ // SEI recovery point
+						0x06, 0x06, 0x01, 0x00, 0x80,
+					},
+					{ // non-IDR (poc 0)
+						0x41, 0xe0, 0x04,
+					},
+				},
+				56890 + 0,
+				56890 + 0,
+			},
+			{
+				[][]byte{{0x41, 0x9a, 0x21, 0x6c, 0x45, 0xff}},
+				56890 + 3000,
+				56890 + 3000,
+			},
+			{
+				[][]byte{{0x41, 0x9a, 0x42, 0x3c, 0x21, 0x93}},
+				56890 + 6000,
+				56890 + 6000,
+			},
+			{
+				[][]byte{{0x41, 0x9a, 0x63, 0x49, 0xe1, 0x0f}},
+				56890 + 9000,
+				56890 + 9000,
+			},
+			{
+				[][]byte{{0x41, 0x9a, 0x86, 0x49, 0xe1, 0x0f}},
+				56890 + 9090,
+				56890 + 18000,
+			},
+			{
+				[][]byte{{0x41, 0x9e, 0xa5, 0x42, 0x7f, 0xf9}},
+				56890 + 12045,
+				56890 + 15000,
+			},
+			{
+				[][]byte{{0x01, 0x9e, 0xc4, 0x69, 0x13, 0xff}},
+				56890 + 12135,
+				56890 + 12000,
+			},
+			{
+				[][]byte{{0x41, 0x9a, 0xc8, 0x4b, 0xa8, 0x42}},
+				56890 + 15101,
+				56890 + 24000,
+			},
+			{
+				[][]byte{
+					{ // IDR
+						0x65, 0x88, 0x84, 0x00, 0x33, 0xff,
+					},
+				},
+				56890 + 18067,
+				56890 + 24000,
+			},
+		},
+	},
+	{
+		"SEI recovery point with odd POC",
+		[]sample{
+			{
+				[][]byte{
+					{ // SPS
+						0x67, 0x64, 0x00, 0x28, 0xac, 0xd9, 0x40, 0x78,
+						0x02, 0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00,
+						0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60,
+						0xc6, 0x58,
+					},
+					{ // SEI recovery point
+						0x06, 0x06, 0x01, 0x00, 0x80,
+					},
+					{ // non-IDR (poc 1)
+						0x41, 0xe0, 0x0c,
+					},
+				},
+				1000,
+				1000,
+			},
+			{
+				[][]byte{{0x41, 0xe0, 0x14}}, // non-IDR (poc 2)
+				2000,
+				2000,
+			},
+			{
+				[][]byte{{0x41, 0xe0, 0x1c}}, // non-IDR (poc 3)
+				3000,
+				3000,
+			},
+			{
+				[][]byte{{0x41, 0xe0, 0x24}}, // non-IDR (poc 4)
+				4000,
+				4000,
+			},
+		},
+	},
 }
 
 func TestDTSExtractor(t *testing.T) {
@@ -595,6 +700,93 @@ func TestDTSExtractor(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDTSExtractorErrors(t *testing.T) {
+	sps := []byte{
+		0x67, 0x64, 0x00, 0x28, 0xac, 0xd9, 0x40, 0x78,
+		0x02, 0x27, 0xe5, 0x84, 0x00, 0x00, 0x03, 0x00,
+		0x04, 0x00, 0x00, 0x03, 0x00, 0xf0, 0x3c, 0x60,
+		0xc6, 0x58,
+	}
+	seiRecoveryPoint := []byte{0x06, 0x06, 0x01, 0x00, 0x80}
+
+	t.Run("no random access frame", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		_, err := ex.Extract([][]byte{sps}, 56890)
+		require.EqualError(t, err, "random access frame not received yet")
+	})
+
+	t.Run("recovery point without a frame", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		_, err := ex.Extract([][]byte{sps, seiRecoveryPoint}, 56890)
+		require.EqualError(t, err, "random access frame not received yet")
+	})
+
+	t.Run("recovery point with invalid frame", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		_, err := ex.Extract([][]byte{sps, seiRecoveryPoint, {0x41}}, 56890)
+		require.EqualError(t, err, "not enough bits")
+	})
+
+	t.Run("SPS not received yet", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		_, err := ex.Extract([][]byte{{0x65, 0x88, 0x84, 0x00, 0x33, 0xff}}, 56890)
+		require.EqualError(t, err, "SPS not received yet")
+	})
+
+	t.Run("pic_order_cnt_type = 1", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		ex.spsp = &SPS{PicOrderCntType: 1, FrameMbsOnlyFlag: true}
+		_, err := ex.Extract([][]byte{{0x65, 0x88, 0x84, 0x00, 0x33, 0xff}}, 56890)
+		require.EqualError(t, err, "pic_order_cnt_type = 1 is not supported yet")
+	})
+
+	t.Run("no-reference NALU before any DTS", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		ex.spsp = &SPS{
+			PicOrderCntType:             0,
+			FrameMbsOnlyFlag:            true,
+			Log2MaxFrameNumMinus4:       0,
+			Log2MaxPicOrderCntLsbMinus4: 2,
+		}
+		ex.randomReceived = true
+		dts, err := ex.Extract([][]byte{{0x06, 0x01, 0x02, 0x08, 0x14, 0x80}}, 56890)
+		require.NoError(t, err)
+		require.Equal(t, int64(56890), dts)
+	})
+
+	t.Run("pause with previous DTS", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		ex.spsp = &SPS{
+			PicOrderCntType:             0,
+			FrameMbsOnlyFlag:            true,
+			Log2MaxFrameNumMinus4:       0,
+			Log2MaxPicOrderCntLsbMinus4: 2,
+		}
+		ex.randomReceived = true
+		ex.prevDTSFilled = true
+		ex.prevDTS = 42
+		ex.pause = 1
+		dts, err := ex.Extract([][]byte{{0x65, 0x88, 0x84, 0x00, 0x33, 0xff}}, 56890)
+		require.NoError(t, err)
+		require.Equal(t, int64(132), dts)
+	})
+
+	t.Run("pause without previous DTS", func(t *testing.T) {
+		ex := NewDTSExtractor()
+		ex.spsp = &SPS{
+			PicOrderCntType:             0,
+			FrameMbsOnlyFlag:            true,
+			Log2MaxFrameNumMinus4:       0,
+			Log2MaxPicOrderCntLsbMinus4: 2,
+		}
+		ex.randomReceived = true
+		ex.pause = 1
+		dts, err := ex.Extract([][]byte{{0x65, 0x88, 0x84, 0x00, 0x33, 0xff}}, 56890)
+		require.NoError(t, err)
+		require.Equal(t, int64(56890), dts)
+	})
 }
 
 func serializeSequence(seq []sample) []byte {

--- a/pkg/codecs/h264/is_random_access.go
+++ b/pkg/codecs/h264/is_random_access.go
@@ -4,8 +4,13 @@ package h264
 func IsRandomAccess(au [][]byte) bool {
 	for _, nalu := range au {
 		typ := NALUType(nalu[0] & 0x1F)
-		if typ == NALUTypeIDR {
+		switch typ {
+		case NALUTypeIDR:
 			return true
+		case NALUTypeSEI:
+			if isSEIRecoveryPoint(nalu) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/codecs/h264/is_random_access_test.go
+++ b/pkg/codecs/h264/is_random_access_test.go
@@ -11,6 +11,12 @@ func TestIsRandomAccess(t *testing.T) {
 		{0x05},
 		{0x07},
 	}))
+	require.Equal(t, true, IsRandomAccess([][]byte{
+		{0x06, 0x06, 0x01, 0x00, 0x80},
+	}))
+	require.Equal(t, false, IsRandomAccess([][]byte{
+		{0x06, 0x05, 0x02, 0xaa, 0xbb, 0x80},
+	}))
 	require.Equal(t, false, IsRandomAccess([][]byte{
 		{0x01},
 	}))

--- a/pkg/codecs/h264/sei.go
+++ b/pkg/codecs/h264/sei.go
@@ -1,0 +1,49 @@
+package h264
+
+// IsSEIRecoveryPoint checks whether a NALU is a recovery point SEI message.
+func IsSEIRecoveryPoint(nalu []byte) bool {
+	return isSEIRecoveryPoint(nalu)
+}
+
+// isSEIRecoveryPoint checks if a SEI NALU contains a recovery point message (payload type 6).
+func isSEIRecoveryPoint(nalu []byte) bool {
+	typ := NALUType(nalu[0] & 0x1F)
+	if typ != NALUTypeSEI {
+		return false
+	}
+
+	pos := 1 // skip NALU header byte
+
+	for pos < len(nalu) {
+		payloadType, p := readSEIByteValue(nalu, pos)
+		pos = p
+
+		if payloadType == 6 {
+			return true
+		}
+
+		payloadSize, p := readSEIByteValue(nalu, pos)
+		pos = p
+
+		pos += payloadSize
+	}
+
+	return false
+}
+
+// readSEIByteValue reads a SEI ff-style encoded value (payloadType/payloadSize),
+// where each byte equal to 0xFF contributes 255 and the first byte different from
+// 0xFF terminates the value (adding its own value). It returns the value and the
+// updated position.
+func readSEIByteValue(nalu []byte, pos int) (int, int) {
+	var v int
+	for pos < len(nalu) {
+		b := nalu[pos]
+		pos++
+		v += int(b)
+		if b != 0xFF {
+			break
+		}
+	}
+	return v, pos
+}

--- a/pkg/codecs/h264/sei.go
+++ b/pkg/codecs/h264/sei.go
@@ -1,10 +1,5 @@
 package h264
 
-// IsSEIRecoveryPoint checks whether a NALU is a recovery point SEI message.
-func IsSEIRecoveryPoint(nalu []byte) bool {
-	return isSEIRecoveryPoint(nalu)
-}
-
 // isSEIRecoveryPoint checks if a SEI NALU contains a recovery point message (payload type 6).
 func isSEIRecoveryPoint(nalu []byte) bool {
 	typ := NALUType(nalu[0] & 0x1F)

--- a/pkg/codecs/h264/sei_test.go
+++ b/pkg/codecs/h264/sei_test.go
@@ -1,0 +1,71 @@
+package h264
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSEIRecoveryPoint(t *testing.T) {
+	cases := []struct {
+		name string
+		nalu []byte
+		out  bool
+	}{
+		{
+			name: "not a SEI NALU",
+			nalu: []byte{byte(NALUTypeNonIDR), 0x06},
+			out:  false,
+		},
+		{
+			name: "single recovery point",
+			nalu: []byte{byte(NALUTypeSEI), 0x06, 0x01, 0x00, 0x80},
+			out:  true,
+		},
+		{
+			name: "recovery point after another SEI message",
+			nalu: []byte{
+				byte(NALUTypeSEI),
+				0x05, 0x02, 0xAA, 0xBB, // user_data_unregistered, size 2
+				0x06, 0x01, 0x00, // recovery point
+				0x80, // rbsp trailing bits
+			},
+			out: true,
+		},
+		{
+			name: "payload type with 0xff continuation",
+			nalu: []byte{
+				byte(NALUTypeSEI),
+				0xFF, 0x05, 0x02, 0xAA, 0xBB, // payload type 260, size 2
+				0x06, 0x01, 0x00, // recovery point
+				0x80, // rbsp trailing bits
+			},
+			out: true,
+		},
+		{
+			name: "payload size with 0xff continuation",
+			nalu: []byte{
+				byte(NALUTypeSEI),
+				0x05, 0xFF, 0x01, 0xaa, 0xbb, // payload type 5, size 256
+				0x80, // rbsp trailing bits
+			},
+			out: false,
+		},
+		{
+			name: "no recovery point",
+			nalu: []byte{byte(NALUTypeSEI), 0x05, 0x02, 0xAA, 0xBB, 0x80},
+			out:  false,
+		},
+		{
+			name: "only NALU header",
+			nalu: []byte{byte(NALUTypeSEI)},
+			out:  false,
+		},
+	}
+
+	for _, ca := range cases {
+		t.Run(ca.name, func(t *testing.T) {
+			require.Equal(t, ca.out, isSEIRecoveryPoint(ca.nalu))
+		})
+	}
+}


### PR DESCRIPTION
Treat a SEI recovery point message (payload type 6) as a random access point, similarly to a CRA in H265, so the DTS extractor can (re)initialize its state from the first coded frame that follows the recovery point.